### PR TITLE
fix(cla): do not create a comment if cla is signed

### DIFF
--- a/src/checkcla.ts
+++ b/src/checkcla.ts
@@ -113,11 +113,11 @@ export async function getclas(pullRequestNo: number) {
     signed = true
   }
   try {
-    const reactedCommitters: ReactedCommitterMap = (await prComment(signed, committerMap, committers, pullRequestNo)) as ReactedCommitterMap
     if (signed) {
       core.info("All committers have signed the CLA")
       return
     }
+    const reactedCommitters: ReactedCommitterMap = (await prComment(signed, committerMap, committers, pullRequestNo)) as ReactedCommitterMap
     if (reactedCommitters) {
       if (reactedCommitters.newSigned) {
         clas.signedContributors.push(...reactedCommitters.newSigned)


### PR DESCRIPTION
Sorry to come straight to PR, cannot open issues in forks.

I'm not an expert in TS or GitHub actions, just curious to know what if.
The logic here is to disable adding CLA-based comments for users who already signed the CLA. Maybe after this change it will stop raising access exception. If you want to keep a CLA comment, this PR is not an option, of course. 